### PR TITLE
fix: Neglect filter weeks card in scraping a course

### DIFF
--- a/src/course.py
+++ b/src/course.py
@@ -56,7 +56,7 @@ class Course:
         files_body = self.course_soup.find_all(class_="card-body")
 
         for item in files_body:
-            """check if card is not a course content, useful for 'Filter weeks' card"""
+            # check if the card is not a course content, useful for `Filter weeks` card
             if item.find('strong') is None:
                 continue
             self.files.append((CMSFile(soup=item, course_path=course_path)))

--- a/src/course.py
+++ b/src/course.py
@@ -56,6 +56,8 @@ class Course:
         files_body = self.course_soup.find_all(class_="card-body")
 
         for item in files_body:
+            if item.find('strong') == None:
+                continue
             self.files.append((CMSFile(soup=item, course_path=course_path)))
 
 

--- a/src/course.py
+++ b/src/course.py
@@ -56,7 +56,8 @@ class Course:
         files_body = self.course_soup.find_all(class_="card-body")
 
         for item in files_body:
-            if item.find('strong') == None:
+            """check if card is not a course content, useful for 'Filter weeks' card"""
+            if item.find('strong') is None:
                 continue
             self.files.append((CMSFile(soup=item, course_path=course_path)))
 


### PR DESCRIPTION
Two courses that are coincidentally taught by the same lecturer have a filter weeks card which I believe filters the contents based on lectures, tutorials, staff etc. This causes an error when searching for the "strong" tags since the "filter" card does not have them, causing a _NoneType.text_ error in the following line.
`self.name = re.sub(self.get_file_regex(), "\\1", self.soup.find("strong").text).strip()` (in the CMSFile class)
Not sure what is the best way to solve this. An attempted solution is to ignore this card when the _strong_ tag is not found. Another possible solution may be based on the card name.